### PR TITLE
Use standard logging levels

### DIFF
--- a/irc_bot/simple_irc_bot.py
+++ b/irc_bot/simple_irc_bot.py
@@ -346,7 +346,7 @@ class SimpleIRCBot(asynchat.async_chat):
     def part(self, channels):
         """PARTs from the channel(s)"""
         if channels:
-            log.verbose('PARTing from channels: %s', ','.join(channels))
+            log.info('PARTing from channels: %s', ','.join(channels))
             self.write('PART %s' % ','.join(channels))
 
     def write(self, msg):


### PR DESCRIPTION
This library was relying on log levels added by FlexGet